### PR TITLE
Fix pagination update when switching folders

### DIFF
--- a/static/js/events.js
+++ b/static/js/events.js
@@ -1,6 +1,6 @@
 //events.js
 import { makeResizable } from './resizer.js';
-import { currentPage, totalPages, loadRootImages, updateGallery } from './gallery.js';
+import { currentPage, totalPages, loadRootImages, updateGallery, renderPagination, setCurrentPage, setTotalPages, itemsPerPage } from './gallery.js';
 import { collapseAll, expandAll, toggleFilesOption, toggleToSublevel } from './fileTree.js';  // Import the missing functions
 
 let selectedFolders = new Set();  // Track the selected folders
@@ -116,8 +116,13 @@ function updateCurrentImagesJson(folderPaths) {
     .then(response => response.json())
     .then(data => {
         console.log('Updated current_images.json with images from folders:', data);
-        // Update the gallery with the new images
-        updateGallery(data, 1);  // Reset to page 1
+        // Reset pagination state
+        setCurrentPage(1);
+        const pages = Math.ceil(data.length / itemsPerPage);
+        setTotalPages(pages);
+        // Update the gallery with the new images and re-render pagination
+        updateGallery(data, 1);
+        renderPagination(pages);
     })
     .catch(error => {
         console.error('Error updating current_images.json:', error);

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,7 +1,15 @@
 // gallery.js
 export let currentPage = 1;
-const itemsPerPage = 60;
+export const itemsPerPage = 60;
 export let totalPages = 0;
+
+export function setCurrentPage(page) {
+    currentPage = page;
+}
+
+export function setTotalPages(pages) {
+    totalPages = pages;
+}
 
 export function loadRootImages() {
     fetch('/update-images-json?folder=Media')


### PR DESCRIPTION
## Summary
- update gallery module with setter helpers for current and total pages
- re-render pagination when folder selection changes

## Testing
- `python3 -m py_compile backend/server.py backend/generate_images_json.py`
- `node --check static/js/events.js`
- `node --check static/js/gallery.js`


------
https://chatgpt.com/codex/tasks/task_e_6840c0f4b1ec8332856b2cbc4d8b3545